### PR TITLE
Add Kubernetes Community Day AMS 2019

### DIFF
--- a/content/community/events/k8s-days-ams-2019-09.md
+++ b/content/community/events/k8s-days-ams-2019-09.md
@@ -1,0 +1,12 @@
+---
+event: Kubernetes Days Amsterdam
+topic: KUDO - Kubernetes Operators, the easy way
+speaker: Matt Jarvis
+date: 2019-09-13
+location: Amsterdam, the Netherlands
+url: https://cloudnative.amsterdam
+---
+
+<!-- some more info about the event could go here -->
+
+<!-- more -->


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

Add KUDO talk details for [Kubernetes Community Day Amsterdam 2019](https://cloudnative.amsterdam)

**Does this PR introduce a user-facing change?**:
```
NONE
```