### PR TITLE
Fix behaviour of toLocaleDateString() subtracting a day

### DIFF
--- a/content/.vuepress/components/EventsIndex.vue
+++ b/content/.vuepress/components/EventsIndex.vue
@@ -55,10 +55,10 @@
     },
     methods: {
       displayDay(dateString) {
-        return new Date(dateString).toLocaleDateString('en-US', { day: '2-digit' })
+        return new Date(dateString).toLocaleDateString('en-US', { timeZone: 'UTC', day: '2-digit' })
       },
       displayMonth(dateString) {
-        return new Date(dateString).toLocaleDateString('en-US', { month: 'short' })
+        return new Date(dateString).toLocaleDateString('en-US', { timeZone: 'UTC', month: 'short' })
       }
     }
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
If your TZ isn't already UTC, the date as formatted by the displayDay
and displayMonth methods could be wrong, as described here:

https://stackoverflow.com/questions/32877278/tolocaledatestring-is-subtracting-a-day

This commit specifies UTC so that it's consist and correct with what's
in the event itself.

**Which issue(s) this PR fixes**:
Fixes #15 
