### PR TITLE
Add missing pages to sidebar

### DIFF
--- a/content/.vuepress/config.js
+++ b/content/.vuepress/config.js
@@ -10,11 +10,31 @@ module.exports = {
               'cli',
               'comparison',
               'concepts',
+              'contributing',
               'controlled-parameter-changes',
               'developing-operators',
+              {
+                title: 'Examples',
+                children: [
+                  'examples/apache-flink',
+                  'examples/apache-kafka',
+                  'examples/apache-zookeeper',
+                  'examples/backups'
+                ]
+              },
               'faq',
               'repository',
-              'testing',
+              {
+                title: 'Testing',
+                children: [
+                  'testing',
+                  'testing/asserts',
+                  'testing/reference',
+                  'testing/steps',
+                  'testing/test-environments',
+                  'testing/tips'
+                ]
+              },
               'update-upgrade-plans'
             ],
             '/blog/': [


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
This adds the "contributing" page and the "examples" and "testing" folders to the sidebar. While these pages were rendered by VuePress, they weren't accessible directly from the website. [Sidebar groups](https://vuepress.vuejs.org/default-theme-config/#sidebar-groups) are used to integrate the "examples" and "testing" folders into the sidebar.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #20 

![Sidebar with added items](https://user-images.githubusercontent.com/2085586/64529280-d220a800-d30a-11e9-97e8-c7d8df3cb4a8.png)


