### PR TITLE
Fix link to Kafka operator in FAQ

### DIFF
--- a/content/docs/faq.md
+++ b/content/docs/faq.md
@@ -15,7 +15,7 @@ KUDO should be used any time you would use an operator. It can provide an advanc
 
 ## What is an Operator?
 
-`Operator` is the high-level description of a deployable service which is represented as an CRD object. An example `Operator` is the [kafka-operator.yaml](https://github.com/kudobuilder/operators/blob/master/repo/stable/kafka/versions/0/kafka-operator.yaml) that you find in the [kudobuilder/operators](https://github.com/kudobuilder/operators) repository.
+`Operator` is the high-level description of a deployable service which is represented as an CRD object. An example `Operator` is the [Kafka Operator](https://github.com/kudobuilder/operators/blob/master/repository/kafka/operator/) that you find in the [kudobuilder/operators](https://github.com/kudobuilder/operators) repository.
 
 Kafka Operator Example
 ```yaml


### PR DESCRIPTION
The previous link resulted in a 404.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**: It fixes a link in the FAQ that was 404ing

**Which issue(s) this PR fixes**: There's no issue for it
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

