### PR TITLE
Add event details for Cloud Native Computing Paris Sept 2019

### DIFF
--- a/content/community/events/cnc-paris-2019-09.md
+++ b/content/community/events/cnc-paris-2019-09.md
@@ -1,10 +1,10 @@
 ---
-event: Cloud Native Paris
+event: Cloud Native Computing Paris
 topic: KUDO - Kubernetes Operators, the easy way
 speaker: Denis Jannot
-date: 2019-10-17
+date: 2019-09-26
 location: Paris, France
-url: 
+url: https://www.meetup.com/Cloud-Native-Computing-Paris/events/264755036
 ---
 
 <!-- some more info about the event could go here -->


### PR DESCRIPTION
**What this PR does / why we need it**:
Add event details for @djannot's talk at [Cloud Native Computing Paris Sept 2019](https://www.meetup.com/Cloud-Native-Computing-Paris/events/264755036).
