### PR TITLE
Refine date comparison for event listing

### DIFF
--- a/content/.vuepress/components/EventsIndex.vue
+++ b/content/.vuepress/components/EventsIndex.vue
@@ -40,15 +40,17 @@
     },
     computed: {
       events() {
+        var today = new Date();
+        today.setHours(0,0,0,0);
         if (this.subset === 'upcoming') {
           return this.$site.pages
             .filter(x => x.path.startsWith('/community/events/') && x.frontmatter.event)
-            .filter(x => new Date(x.frontmatter.date) >= new Date())
+            .filter(x => new Date(x.frontmatter.date) >= today)
             .sort((a, b) => new Date(a.frontmatter.date) - new Date(b.frontmatter.date));
         } else {
           return this.$site.pages
             .filter(x => x.path.startsWith('/community/events/') && x.frontmatter.event)
-            .filter(x => new Date(x.frontmatter.date) < new Date())
+            .filter(x => new Date(x.frontmatter.date) < today)
             .sort((a, b) => new Date(b.frontmatter.date) - new Date(a.frontmatter.date));
         }
       },


### PR DESCRIPTION
**What this PR does / why we need it**:
Tweak how the date is checked for upcoming / past events so it's performed purely off the date.  This fixes the problem with events appearing in the past even though they might actually be on the same day they're being viewed.

