### PR TITLE
Change speaker for Dallas Kubernetes Meetup

### DIFF
--- a/content/community/events/dallas-kubernetes-2019-10.md
+++ b/content/community/events/dallas-kubernetes-2019-10.md
@@ -1,7 +1,7 @@
 ---
 event: Dallas Kubernetes Meetup October 2019
 topic: KUDO - Kubernetes Operators, the easy way
-speaker: Valerian Jone
+speaker: Chris Mays
 date: 2019-10-24
 location: Dallas, TX
 url: https://www.meetup.com/Dallas-Kubernetes-Meetup/


### PR DESCRIPTION
**What this PR does / why we need it**:
A change of plan means that Chris Mays will be speaking at the Dallas K8s Meetup instead of Valerian.

