### PR TITLE
Add details for KUDO CNCF webinar event

### DIFF
--- a/content/community/events/cncf-kudo-webinar-2019-10.md
+++ b/content/community/events/cncf-kudo-webinar-2019-10.md
@@ -1,0 +1,12 @@
+---
+event: CNCF Webinar Series
+topic: Introducing the Kubernetes Universal Declarative Operator
+speaker: Gerred Dillon
+date: 2019-10-16
+location: Online
+url: https://www.cncf.io/webinars/introducing-the-kubernetes-universal-declarative-operator/
+---
+
+This is an online event, use [this link](https://zoom.us/webinar/register/1315705584423/WN_4aeXjmSoS3SONZxCSAwDxg) to register.
+
+<!-- more -->


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit adds details for the CNCF KUDO Webinar online event.