### PR TITLE
Add link to CNCF Webinar on KUDO

### DIFF
--- a/content/community/README.md
+++ b/content/community/README.md
@@ -22,6 +22,7 @@ Contribute to KUDO development:
 
 KUDO content from around the web:
 
+- [CNCF Webinar series: Introducing the Kubernetes Universal Declarative Operator](https://www.cncf.io/webinars/introducing-the-kubernetes-universal-declarative-operator/), presented by Gerred Dillon
 - [KUDO tutorial by Michael Beisiegel](https://github.com/realmbgl/kudo-tutorial)
 - [Cloud Native London 2019: Introducing KUDO – Kubernetes Operators the easy way by Matt Jarvis](https://skillsmatter.com/skillscasts/14045-kubernetes-operators-the-easy-way)
 - [OSDC 2019: Introducing KUDO – Kubernetes Operators the easy way by Matt Jarvis](https://youtu.be/qAUmRfbd300)


### PR DESCRIPTION
**What this PR does / why we need it**:
Update the community content section to include a link to the CNCF webinar on KUDO.
