### PR TITLE
Update author template to handle links to LinkedIn profiles

### DIFF
--- a/content/.vuepress/components/Author.vue
+++ b/content/.vuepress/components/Author.vue
@@ -18,13 +18,19 @@
                     <a v-bind:href="'https://github.com/' + author.alias"
                        target="_blank"
                        rel="noopener noreferrer">GitHub</a><OutboundLink/>
-                </span>
+            </span>
             <!-- twitter alias is optional -->
             <span v-if="author.twitter">
                     <a v-bind:href="'https://twitter.com/' + author.twitter"
                        target="_blank"
                        rel="noopener noreferrer">Twitter</a><OutboundLink/>
-                </span>
+            </span>
+            <!-- linkedin alias is also optional -->
+            <span v-if="author.linkedin">
+                    <a v-bind:href="'https://linkedin.com/in/' + author.linkedin"
+                       target="_blank"
+                       rel="noopener noreferrer">LinkedIn</a><OutboundLink/>
+            </span>
         </div>
 
     </div>

--- a/content/community/team/matt.md
+++ b/content/community/team/matt.md
@@ -5,6 +5,7 @@ alias: mattj-io
 name: Matt
 avatar: matt.png
 twitter: mattj_io
+linkedin: mattjarvis08
 about:
   Matt runs the Open Source Program Office at D2iQ. He's a regular speaker at conferences and meetups all over the world, and has been building stuff with open source software for longer than he cares to remember. 
 ---

--- a/content/community/team/nick.md
+++ b/content/community/team/nick.md
@@ -5,6 +5,7 @@ alias: yankcrime
 name: Nick
 avatar: nick.png
 twitter: yankcrime
+linkedin: nickj
 about:
   Nick has worked as a sysadmin, engineer, architect with a career spanning nearly two decades across a wide variety of industries and sectors. He's passionate about new technologies and methodologies, especially those in relation to Open Source, virtualisation, orchestration, automation, and all forms of cloud computing.
 ---


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is a small update to the author template to render an optional link to a LinkedIn profile.
