### PR TITLE
Add a teaser component

### DIFF
--- a/content/.vuepress/config.js
+++ b/content/.vuepress/config.js
@@ -126,6 +126,11 @@ module.exports = {
             before: name => `<div class="flag"><code class="title" v-pre>${name}</code>`,
             after: '</div>',
         }],
+        ['container', {
+            type: 'teaser',
+            before: name => `<div class="teaser custom-block"><p class="custom-block-title">${name}</p>`,
+            after: '</div>',
+        }],
         [ 'feed', feed_options ]
     ]
 };

--- a/content/.vuepress/theme/styles/custom-blocks.styl
+++ b/content/.vuepress/theme/styles/custom-blocks.styl
@@ -2,7 +2,7 @@
   .custom-block-title
     font-weight 600
     margin-bottom -0.4rem
-  &.tip, &.warning, &.danger
+  &.tip, &.warning, &.danger, &.teaser
     padding .1rem 1.5rem
     border-left-width .5rem
     border-left-style solid
@@ -25,3 +25,9 @@
     border-color $dangerHighlightColor
     .custom-block-title
       color $dangerHighlightColor
+  &.teaser
+    background-color $teaserBackgroundColor
+    border-color $teaserHighlightColor
+    .custom-block-title
+      font-size 1.4em
+      color $teaserHighlightColor

--- a/content/.vuepress/theme/styles/palette.styl
+++ b/content/.vuepress/theme/styles/palette.styl
@@ -13,6 +13,8 @@ $warnBackgroundColor = #594A0F
 $warnHighlightColor = #b1941e
 $dangerBackgroundColor = #490808
 $dangerHighlightColor = #97040b
+$teaserBackgroundColor = #31075C
+$teaserHighlightColor = #23D6BD
 
 // bright theme -->
 //$accentColor = #2796fc
@@ -29,3 +31,5 @@ $dangerHighlightColor = #97040b
 //$warnHighlightColor = #C46F00
 //$dangerBackgroundColor = #E2BBBB
 //$dangerHighlightColor = #97040b
+//$teaserBackgroundColor = #31075C
+//$teaserHighlightColor = #23D6BD

--- a/content/README.md
+++ b/content/README.md
@@ -16,6 +16,12 @@ footer: Written in Go, maintained by good people.
 
 ---
 
+::: teaser Featured Content
+For a great introduction to KUDO watch the CNCF Webinar series: [Introducing the Kubernetes Universal Declarative Operator](https://www.cncf.io/webinars/introducing-the-kubernetes-universal-declarative-operator/) by [Gerred Dillon](community/team/gerred.md). In order to get an idea about the history of KUDO, a high level comparison between KUDO and Mesos frameworks, and to learn something about Gerred's chickens, listen to the [Kubernetes Podcast #78](https://kubernetespodcast.com/episode/078-kudo/) (KUDO, with Gerred Dillon).
+
+You can find more recordings, tutorials, etc on our [community page](community/README.md#community-content). 
+:::
+
 # There's more to life than Kubernetes
 
 Software like databases weren't built only to run on Kubernetes. They already have a rich set of tooling for deployment and operations, no matter where they are deployed. These tools are written, tested, and maintained by the experts who know this software best. 

--- a/content/community/README.md
+++ b/content/community/README.md
@@ -23,6 +23,7 @@ Contribute to KUDO development:
 KUDO content from around the web:
 
 - [CNCF Webinar series: Introducing the Kubernetes Universal Declarative Operator](https://www.cncf.io/webinars/introducing-the-kubernetes-universal-declarative-operator/), presented by Gerred Dillon
+- [Kubernetes Podcast #78](https://kubernetespodcast.com/episode/078-kudo/) (KUDO, with gerred Dillon).
 - [KUDO tutorial by Michael Beisiegel](https://github.com/realmbgl/kudo-tutorial)
 - [Cloud Native London 2019: Introducing KUDO – Kubernetes Operators the easy way by Matt Jarvis](https://skillsmatter.com/skillscasts/14045-kubernetes-operators-the-easy-way)
 - [OSDC 2019: Introducing KUDO – Kubernetes Operators the easy way by Matt Jarvis](https://youtu.be/qAUmRfbd300)


### PR DESCRIPTION
Use the teaser to promote the CNCF webinar as well as the Kubernetes Podcast with Gerred prominently on the landing page.

See the teaser [here](https://deploy-preview-85--kudo-www.netlify.com/)