### PR TITLE
Add CNCF and K8s Minneapolis 2020 event

### DIFF
--- a/content/community/README.md
+++ b/content/community/README.md
@@ -23,7 +23,7 @@ Contribute to KUDO development:
 KUDO content from around the web:
 
 - [CNCF Webinar series: Introducing the Kubernetes Universal Declarative Operator](https://www.cncf.io/webinars/introducing-the-kubernetes-universal-declarative-operator/), presented by Gerred Dillon
-- [Kubernetes Podcast #78](https://kubernetespodcast.com/episode/078-kudo/) (KUDO, with gerred Dillon).
+- [Kubernetes Podcast #78](https://kubernetespodcast.com/episode/078-kudo/) (KUDO, with Gerred Dillon).
 - [KUDO tutorial by Michael Beisiegel](https://github.com/realmbgl/kudo-tutorial)
 - [Cloud Native London 2019: Introducing KUDO – Kubernetes Operators the easy way by Matt Jarvis](https://skillsmatter.com/skillscasts/14045-kubernetes-operators-the-easy-way)
 - [OSDC 2019: Introducing KUDO – Kubernetes Operators the easy way by Matt Jarvis](https://youtu.be/qAUmRfbd300)

--- a/content/community/events/cncf-minneapolis-2020-01.md
+++ b/content/community/events/cncf-minneapolis-2020-01.md
@@ -1,0 +1,12 @@
+---
+event: Cloud Native and Kubernetes Minneapolis
+topic: Kubernetes Operators Delivered with KUDO
+speaker: Ken Sipe
+date: 2020-01-23
+location: Minneapolis, US
+url: https://www.meetup.com/Cloud-Native-Minneapolis/events/vrzqhrybccbfc/
+---
+
+<!-- some more info about the event could go here -->
+
+<!-- more -->


### PR DESCRIPTION
**What this PR does / why we need it**:

Add an event for @kensipe's talk at the Cloud Native and K8s Minneapolis Meetup in January.
