### PR TITLE
Fix the getting started ZK / Kafka examples for 0.8.0

### DIFF
--- a/content/docs/examples/apache-kafka.md
+++ b/content/docs/examples/apache-kafka.md
@@ -7,44 +7,47 @@ type: docs
 
 ## Dependencies
 
-Kafka depends on Zookeeper so we need to run it first. Follow the [Zookeeper example](apache-zookeeper.md) to run a basic cluster.
+Apache Kafka depends on ZooKeeper so we need to run it first. Follow the [ZooKeeper example](apache-zookeeper.md) to run a basic cluster.
 
 ## Run Kafka
 
-Create a Kafka cluster
+Install the KUDO Kafka Operator to create a Kafka cluster with the default options:
+
 ```bash
-$ kubectl kudo install kafka --instance=kafka
-operator.kudo.dev/kafka unchanged
-operatorversion.kudo.dev/v1alpha1/kafka-0.2.0 created
-instance.kudo.dev/v1alpha1/kafka created
+$ kubectl kudo install kafka
+operator.kudo.dev/v1beta1/kafka created
+operatorversion.kudo.dev/v1beta1/kafka-1.0.0 created
+instance.kudo.dev/v1beta1/kafka-instance created
 ```
 
 `kubectl kudo install kafka` creates the `Operator`, `OperatorVersion` and `Instance` CRDs of the Kafka package.
-When an instance is created, the default `deploy` plan is executed
+
+When an instance is created, the default `deploy` plan is executed:
 
 ```
 $ kubectl get instances
-NAME                    AGE
-kafka   13s
+NAME                 AGE
+kafka-instance       24s
+zookeeper-instance   24m
 ```
 
 The stateful set defined in the `OperatorVersion` comes up with 3 pods:
 
 ```bash
-$ kubectl get statefulset kafka-kafka
-NAME          READY   AGE
-kafka-kafka   3/3     56s
+$ kubectl get statefulset kafka-instance-kafka
+NAME                   READY   AGE
+kafka-instance-kafka   3/3     55s
 ```
 
 ```bash
 $ kubectl get pods
-NAME             READY   STATUS    RESTARTS   AGE
-kafka-kafka-0    1/1     Running   0          83s
-kafka-kafka-1    1/1     Running   0          61s
-kafka-kafka-2    1/1     Running   0          34s
-zk-zookeeper-0   1/1     Running   0          6m56s
-zk-zookeeper-1   1/1     Running   0          6m56s
-zk-zookeeper-2   1/1     Running   0          6m56s
+NAME                             READY   STATUS    RESTARTS   AGE
+kafka-instance-kafka-0           1/1     Running   0          7m7s
+kafka-instance-kafka-1           1/1     Running   0          6m22s
+kafka-instance-kafka-2           1/1     Running   0          5m36s
+zookeeper-instance-zookeeper-0   1/1     Running   0          30m
+zookeeper-instance-zookeeper-1   1/1     Running   0          30m
+zookeeper-instance-zookeeper-2   1/1     Running   0          30m
 ```
 
 You can find more details around configuring a Kafka cluster in the [KUDO Kafka documentation](https://github.com/kudobuilder/operators/tree/master/repository/kafka).

--- a/content/docs/examples/apache-zookeeper.md
+++ b/content/docs/examples/apache-zookeeper.md
@@ -1,39 +1,43 @@
 ---
-title: Apache Zookeeper
+title: Apache ZooKeeper
 type: docs
 ---
 
-# Apache Zookeeper
+# Apache ZooKeeper
 
-Create a Zookeeper cluster
+Install the KUDO ZooKeeper Operator to create a cluster with the default settings:
+
 ```bash
-$ kubectl kudo install zookeeper --instance=zk
-operator.kudo.dev/v1alpha1/zookeeper created
-operatorversion.kudo.dev/v1alpha1/zookeeper-0.1.0 created
-instance.kudo.dev/v1alpha1/zk created
+$ kubectl kudo install zookeeper
+operator.kudo.dev/v1beta1/zookeeper created
+operatorversion.kudo.dev/v1beta1/zookeeper-0.2.0 created
+instance.kudo.dev/v1beta1/zookeeper-instance created
 ```
 
-`kubectl kudo install zookeeper` creates the `Operator`, `OperatorVersion` and `Instance` CRDs of the Zookeeper package.
-When an instance is created, the default `deploy` plan is executed
+`kubectl kudo install zookeeper` creates the `Operator`, `OperatorVersion` and `Instance` CRDs of the ZooKeeper package.
 
-```
+When an instance is created, the default `deploy` plan is executed:
+
+```bash
 $ kubectl get instances
-NAME                  AGE
-zk   11s
+NAME                 AGE
+zookeeper-instance   3m15s
 ```
 
 The `statefulset` defined in the `OperatorVersion` comes up with 3 pods:
 
 ```bash
-$ kubectl get statefulset zk-zookeeper
-NAME           READY   AGE
-zk-zookeeper   3/3     1m20s
+$ kubectl get statefulset zookeeper-instance-zookeeper
+NAME                           READY   AGE
+zookeeper-instance-zookeeper   3/3     95s
 ```
 
 ```bash
 $ kubectl get pods
-NAME             READY   STATUS    RESTARTS   AGE
-zk-zookeeper-0   1/1     Running   0          3m43s
-zk-zookeeper-1   1/1     Running   0          3m43s
-zk-zookeeper-2   1/1     Running   0          3m43s
+NAME                             READY   STATUS    RESTARTS   AGE
+zookeeper-instance-zookeeper-0   1/1     Running   0          2m2s
+zookeeper-instance-zookeeper-1   1/1     Running   0          2m2s
+zookeeper-instance-zookeeper-2   1/1     Running   0          2m1s
 ```
+
+At this point you have a functioning three-node ZooKeeper cluster;  A [`validation` task](https://github.com/kudobuilder/operators/blob/master/repository/zookeeper/operator/templates/validation.yaml) is run as part of the deployment which ensures that it's in a healthy state and ready to service requests.


### PR DESCRIPTION
**What this PR does / why we need it**:
The getting started examples for ZooKeeper and Kafka need a few changes to bring them inline with some of the new features in KUDO 0.8.0, especially with regards to instance naming.
