### PR TITLE
Add date for Cloud Native Night Munich

### DIFF
--- a/content/community/events/cloud-native-night-munich-2020-01.md
+++ b/content/community/events/cloud-native-night-munich-2020-01.md
@@ -1,0 +1,12 @@
+---
+event: Cloud Native Night Munich
+topic: KUDO - Kubernetes Operators, the easy way
+speaker: Nick Jones
+date: 2020-01-29
+location: Munich, Germany
+url: https://www.meetup.com/cloud-native-muc/
+---
+
+<!-- some more info about the event could go here -->
+
+<!-- more -->


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds an event for a KUDO talk at a future Cloud Native Night Munich.
