### PR TITLE
Fix Example missing AppVersion definition

### DIFF
--- a/content/docs/developing-operators.md
+++ b/content/docs/developing-operators.md
@@ -25,6 +25,7 @@ apiVersion: kudo.dev/v1beta1
 name: "first-operator"
 version: "0.1.0"
 kubernetesVersion: 1.13.0
+appVersion: 1.17.6
 maintainers:
   - name: Your name
     email: <your@email.com>


### PR DESCRIPTION


**What this PR does / why we need it**:

In the Example file `templates/deployment.yaml` refer this variable `{{ .AppVersion }}`, and `operator.yaml` missed. Which will be lead to create operator instance  success, but create deployment failed.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

the git repository is fine, but i using the example on this document failed, as this reason
