### PR TITLE
Update KUDO description on the home page and embed CNCF webinar video.

### DIFF
--- a/content/.vuepress/components/EmbeddedVideo.vue
+++ b/content/.vuepress/components/EmbeddedVideo.vue
@@ -1,0 +1,35 @@
+<template>
+    <div class="embed-container">
+        <iframe width="560" height="315" :src="url" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    </div>
+</template>
+
+<script>
+  export default {
+    props: {
+      url: {
+        type: String,
+        description: "The video URL"
+      }
+    }
+  }
+</script>
+
+<style lang="stylus" scoped>
+    .embed-container {
+        position: relative;
+        padding-bottom: 56.25%; /* ratio 16x9 */
+        height: 0;
+        overflow: hidden;
+        width: 100%;
+        height: auto;
+    }
+    .embed-container iframe {
+
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+    }
+</style>

--- a/content/README.md
+++ b/content/README.md
@@ -18,25 +18,7 @@ footer: Written in Go, maintained by good people.
 
 ::: teaser Watch the Intro Video
 
-<div class="embed-container">
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/j2A8vl0m2hs" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-</div>
-<style>.embed-container {
-  position: relative; 
-  padding-bottom: 56.25%; /* ratio 16x9 */
-  height: 0; 
-  overflow: hidden; 
-  width: 100%;
-  height: auto;
-}
-.embed-container iframe {
-
-  position: absolute; 
-  top: 0; 
-  left: 0; 
-  width: 100%; 
-  height: 100%; 
-  }</style>```
+<EmbeddedVideo url="https://www.youtube.com/embed/j2A8vl0m2hs" />
 
 Or listen to the [Kubernetes Podcast #78](https://kubernetespodcast.com/episode/078-kudo/) to hear about the origin and history of KUDO.
 

--- a/content/README.md
+++ b/content/README.md
@@ -7,19 +7,22 @@ actionText: ⇝ Get Started ⇜
 actionLink: /docs/
 features:
 - title: Focus on your software …
-  details: The Kubernetes Universal Declarative Operator (KUDO) is a highly productive toolkit for writing operators for Kubernetes.
+  details: The Kubernetes Universal Declarative Operator (KUDO) is a highly productive toolkit for writing Kubernetes Operators.
 - title: … not deploying it to Kubernetes
   details: Using KUDO, you can deploy your applications, give your users the tools they need to operate it, and understand how it's behaving in their environments – all without a PhD in Kubernetes.
-- title: Use declarative templates
-  details: KUDO let’s you configure an operator’s lifecycle using a declarative spec. You don’t have to write Go unless you want to.
+- title: Automate Day-2 Operations
+  details: KUDO lets you configure an Operator’s entire lifecycle using a declarative spec, including things like backup/restore. You don’t have to write Go unless you want to.
 footer: Written in Go, maintained by good people.
 
 ---
 
-::: teaser Featured Content
-For a great introduction to KUDO watch the CNCF Webinar series: [Introducing the Kubernetes Universal Declarative Operator](https://www.cncf.io/webinars/introducing-the-kubernetes-universal-declarative-operator/). In order to get an idea about the history of KUDO, a high level comparison between KUDO and Mesos frameworks, listen to the [Kubernetes Podcast #78](https://kubernetespodcast.com/episode/078-kudo/).
+::: teaser Watch the Intro Video
 
-You can find more recordings, tutorials, etc on our [community page](community/README.md#community-content). 
+<iframe width="560" height="315" src="https://www.youtube.com/embed/j2A8vl0m2hs" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+Or listen to the [Kubernetes Podcast #78](https://kubernetespodcast.com/episode/078-kudo/) to hear about the origin and history of KUDO.
+
+You can find more talks, tutorials, and events on our [community page](community/README.md#community-content).
 :::
 
 <SpecialHeader text="User Stories" />

--- a/content/README.md
+++ b/content/README.md
@@ -18,7 +18,25 @@ footer: Written in Go, maintained by good people.
 
 ::: teaser Watch the Intro Video
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/j2A8vl0m2hs" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<div class="embed-container">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/j2A8vl0m2hs" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+<style>.embed-container {
+  position: relative; 
+  padding-bottom: 56.25%; /* ratio 16x9 */
+  height: 0; 
+  overflow: hidden; 
+  width: 100%;
+  height: auto;
+}
+.embed-container iframe {
+
+  position: absolute; 
+  top: 0; 
+  left: 0; 
+  width: 100%; 
+  height: 100%; 
+  }</style>```
 
 Or listen to the [Kubernetes Podcast #78](https://kubernetespodcast.com/episode/078-kudo/) to hear about the origin and history of KUDO.
 


### PR DESCRIPTION
This merges in changes from #105 and extracts the iFrame code/style into a reusable vue component.