### PR TITLE
Add events for Cloud Native Nordics Tour and for Manchester

### DIFF
--- a/content/community/events/cloud-native-aalborg-2020-01.md
+++ b/content/community/events/cloud-native-aalborg-2020-01.md
@@ -1,0 +1,12 @@
+---
+event: Cloud Native Aalborg
+topic: Introducing KUDO - Kubernetes Operators, the easy way
+speaker: Nick Jones
+date: 2020-02-21
+location: Aalborg, Denmark
+url: https://www.meetup.com/Cloud-Native-Aalborg/events/
+---
+
+<!-- some more info about the event could go here -->
+
+<!-- more -->

--- a/content/community/events/cloud-native-bergen-2020-01.md
+++ b/content/community/events/cloud-native-bergen-2020-01.md
@@ -1,0 +1,12 @@
+---
+event: DevOps and Cloud Native Bergen
+topic: Introducing KUDO - Kubernetes Operators, the easy way
+speaker: Nick Jones
+date: 2020-01-23
+location: Bergen, Norway
+url: https://www.meetup.com/cloudnative-bergen/events/266338983/
+---
+
+<!-- some more info about the event could go here -->
+
+<!-- more -->

--- a/content/community/events/cloud-native-copenhagen-2020-01.md
+++ b/content/community/events/cloud-native-copenhagen-2020-01.md
@@ -1,0 +1,12 @@
+---
+event: Cloud Native Copenhagen
+topic: Introducing KUDO - Kubernetes Operators, the easy way
+speaker: Nick Jones
+date: 2020-02-20
+location: Copenhagen, Denmark
+url: https://www.meetup.com/Cloud-Native-Copenhagen/
+---
+
+<!-- some more info about the event could go here -->
+
+<!-- more -->

--- a/content/community/events/cloud-native-manchester-2020-03.md
+++ b/content/community/events/cloud-native-manchester-2020-03.md
@@ -1,0 +1,12 @@
+---
+event: Cloud Native and Kubernetes Manchester
+topic: Introducing KUDO - Kubernetes Operators, the easy way
+speaker: Nick Jones
+date: 2020-02-05
+location: Manchester, England
+url: https://www.meetup.com/Cloud-Native-Kubernetes-Manchester/events/265849784/
+---
+
+<!-- some more info about the event could go here -->
+
+<!-- more -->

--- a/content/community/events/cloud-native-oslo-2020-01.md
+++ b/content/community/events/cloud-native-oslo-2020-01.md
@@ -2,7 +2,7 @@
 event: Cloud Native and Kubernetes Oslo
 topic: KUDO - Kubernetes Operators, the easy way
 speaker: Nick Jones
-date: 2020-01-23
+date: 2020-01-22
 location: Oslo, Norway
 url: https://www.meetup.com/Cloud-Native-and-Kubernetes-Oslo/
 ---


### PR DESCRIPTION
**What this PR does / why we need it**:

Add dates and event details for an upcoming KUDO tour of the Nordics.

Also add date for Cloud Native and Kubernetes Manchester.


