### PR TITLE
Fix dates for Aalborg and Copenhagen talks

### DIFF
--- a/content/community/events/cloud-native-aalborg-2020-01.md
+++ b/content/community/events/cloud-native-aalborg-2020-01.md
@@ -2,9 +2,9 @@
 event: Cloud Native Aalborg
 topic: Introducing KUDO - Kubernetes Operators, the easy way
 speaker: Nick Jones
-date: 2020-02-21
+date: 2020-01-21
 location: Aalborg, Denmark
-url: https://www.meetup.com/Cloud-Native-Aalborg/events/
+url: https://www.meetup.com/Cloud-Native-Aalborg/events/263745353/
 ---
 
 <!-- some more info about the event could go here -->

--- a/content/community/events/cloud-native-copenhagen-2020-01.md
+++ b/content/community/events/cloud-native-copenhagen-2020-01.md
@@ -2,9 +2,9 @@
 event: Cloud Native Copenhagen
 topic: Introducing KUDO - Kubernetes Operators, the easy way
 speaker: Nick Jones
-date: 2020-02-20
+date: 2020-01-20
 location: Copenhagen, Denmark
-url: https://www.meetup.com/Cloud-Native-Copenhagen/
+url: https://www.meetup.com/Cloud-Native-Copenhagen/events/267132639/
 ---
 
 <!-- some more info about the event could go here -->


### PR DESCRIPTION
**What this PR does / why we need it**:
The dates for these two talks are in January, not February.