### PR TITLE
Operator parameters

### DIFF
--- a/content/.vuepress/config.js
+++ b/content/.vuepress/config.js
@@ -52,6 +52,7 @@ module.exports = {
                         'concepts',
                         'first-operator',
                         'tasks',
+                        'operator-parameters',
                         {
                             title: 'Examples',
                             children: [
@@ -131,6 +132,11 @@ module.exports = {
         ['container', {
             type: 'flag',
             before: name => `<div class="flag"><code class="title" v-pre>${name}</code>`,
+            after: '</div>',
+        }],
+        ['container', {
+            type: 'attribute',
+            before: name => `<div class="attribute"><code class="title" v-pre>${name}</code>`,
             after: '</div>',
         }],
         ['container', {

--- a/content/.vuepress/theme/styles/attribute.styl
+++ b/content/.vuepress/theme/styles/attribute.styl
@@ -1,0 +1,16 @@
+.attribute
+  margin 1rem 0
+  .title
+    font-weight bold
+    padding .1rem 0
+  p
+    margin-block-start 0
+    margin-block-end 0.2em
+    padding .5rem 1rem
+  ul, ol
+    margin-block-start 0
+    margin-block-end 0.2em
+    padding-left 2.2em
+  .extra-class
+    margin-left 1rem
+    padding-left 0.2rem

--- a/content/.vuepress/theme/styles/index.styl
+++ b/content/.vuepress/theme/styles/index.styl
@@ -1,3 +1,4 @@
+@require './attribute'
 @require './config'
 @require './code'
 @require './custom-blocks'

--- a/content/docs/first-operator.md
+++ b/content/docs/first-operator.md
@@ -95,37 +95,8 @@ Plans allow operators to see what the operator is currently doing, and to visual
 
 ## Params File
 
-`params.yaml` defines all parameters that can be used to customize your operator installation. You have to define the name of the parameter and optionally a default value. If not specified otherwise, all parameters in this list are treated as required parameters. For parameters that don't specify default values, you must provide a value during installation, otherwise the installation will fail.
-
-A more detailed example of `params.yaml` may look as following:
-
-```yaml
-apiVersion: kudo.dev/v1beta1
-parameters:
-  - name: BACKUP_FILE
-    description: "Filename to save the backups to"
-    default: "backup.sql"
-    displayName: "BackupFile"
-  - name: PASSWORD
-    default: "password"
-    trigger: backup
-  - name: OPTIONAL_PARAM
-    description: "This parameter is not required"
-    required: False
-  - name: REQUIRED_PARAM
-    description: "This parameter is required but does not have a default value"
-    required: True
-```
-
-Let's look at these parameters:
-* The `BACKUP_FILE` parameter provides a default value, so a user does not need to specify anything unless they want to change that value.
-* The `OPTIONAL_PARAM` is explicitly not required, so even though it doesn't come with a default value, not providing a value for this parameter won't fail the installation.
-* The `REQUIRED_PARAM` is required but does not provide a default value. For such parameters, users are expected to provide a value for `kubectl kudo install youroperator -p REQUIRED_PARAM=value`.
-* The `PASSWORD` parameter exposes one more feature of `params.yaml`: you can `trigger` specific plans when changing a parameter.
-
-### Triggers
-
-`trigger` is an optional field which points to an existing plan in `operator.yaml`. When you update a parameter after an instance has been installed, the plan specified gets triggered as a result of your change. In other words, this plan will apply the parameter change to your Kubernetes objects. If no trigger is specified, the `update` plan will be triggered by default. If no `update` plan exists for this operator, the `deploy` plan is run.
+`params.yaml` defines all parameters that can be used to customize your operator installation.
+They are described in more detail in the [document about operator parameters](operator-parameters.html).
 
 ## Templates
 

--- a/content/docs/operator-parameters.md
+++ b/content/docs/operator-parameters.md
@@ -1,0 +1,99 @@
+# Operator Parameters
+
+This document explains what operator parameters are and how they work in KUDO.
+
+## What are operator parameters
+
+Operator parameters are key-value pairs declared by the operator developer.
+
+The operator user may [override](#overriding-parameters) their values at deployment time.
+This allows customizing the behavior of an operator.
+
+## Declaring parameters
+
+Operator developer declares parameters in a `params.yaml` file.
+This file is mandatory and must be present in the root directory of an operator.
+
+If the operator developer does not wish to provide any parameters, the file may be empty.
+
+The following example illustrates the structure of the file:
+
+```yaml
+apiVersion: kudo.dev/v1beta1
+parameters:
+  - name: BACKUP_FILE
+    description: "Filename to save the backups to."
+    default: "backup.sql"
+    displayName: "BackupFile"
+  - name: PASSWORD
+    default: "password"
+    trigger: backup
+  - name: OPTIONAL_PARAM
+    description: "This parameter is not required."
+    required: False
+  - name: REQUIRED_PARAM
+    description: "This parameter is required but does not have a default value."
+    required: True
+```
+
+A parameter declaration consists of the following attributes:
+
+::: attribute name
+Provides a name of the parameter. Required.
+It is a convention to use upper-case and separate words with underscores.
+:::
+
+::: attribute displayName
+Provides an alternative name of the parameter. Optional.
+Currently not used anywhere.
+May be used by user interfaces to KUDO.
+:::
+
+::: attribute description
+A description of the purpose of the parameter. Optional.
+Currently not used anywhere.
+May be used by user interfaces to KUDO.
+:::
+
+::: attribute default
+A default value of the parameter. Optional.
+Note that omitting this attribute will make the parameter required by default.
+You may change that with the `required` attribute.
+:::
+
+::: attribute required
+Whether a value for this parameter must be [explicitly provided at installation time](#overriding-parameters). Optional.
+Failure to provide a value at installation time will prevent installation from happening.
+:::
+
+::: attribute trigger
+Which [plan should be triggered](#triggers) when this parameter is changed after initial installation. Optional.
+If you do not specify this attribute, the `update` or `deploy` [plan will be triggered](#triggers).
+:::
+
+## Overriding parameters
+
+Parameter values may be overridden from the CLI by the operator user.
+
+The `install`, `upgrade` and `update` subcommands of `kubectl kudo` take the `--parameter` flag
+(which may be abbreviated as `-p`).
+
+The argument to that flag has the form `PARAMETER_NAME=parameter_value`.
+
+This flag may be specified many times to change more parameters in a single run.
+
+## Triggers
+
+Operator developer may specify the name of the [plan](concepts.html#plan) which should be triggered
+when the value of this parameter is changed in an update.
+
+In other words, this plan will apply the parameter change to your Kubernetes application.
+
+If no trigger is specified, the `update` plan will be triggered by default.
+
+If no `update` plan exists for this operator, the `deploy` plan is triggered.
+
+::: warning
+It is currently not specified what happens when a single update changes parameters which refer
+to more than one trigger plan.
+:::

--- a/content/internal-docs/README.md
+++ b/content/internal-docs/README.md
@@ -23,6 +23,7 @@ This documentation uses a few custom components which are meant to help writing 
 - The [EventsIndex](events-index.md) component is used to render upcoming and past events.
 - The [CustomBadge](custom-badge.md) should be used to highlight software versions capability (e.g. introduction or deprecation).
 - The [custom block](custom-blocks.md) `flag` notation should be used to document command line flags, CLI commands, or other code related functionality.
+- The [custom block](custom-blocks.md) `attribute` notation should be used to document YAML file structure
 
 ## VuePress native functionality
 

--- a/content/internal-docs/custom-blocks.md
+++ b/content/internal-docs/custom-blocks.md
@@ -12,9 +12,35 @@ Your markdown content goes here.
 You may need to url encode certain special characters in order to render them **in the flag title**. `<` or `>` have to be urlencoded with `&lt;` and `&gt;`, respectively. This is because VuePress allows rendering Vue components in the title, which are referenced in html markup notation like `<CustomBadge text="beta"/>`.
 :::
 
-## Flag
+## Custom Block Properties
 
-This documentation comes with a pre-configured custom block formatting of type `flag`. Use this to document CLI commands, configuration flags, and similar ways to configure and customize KUDO:
+Custom blocks have two properties:
+
+::: block type
+The type is defined by the first word following the opening `:::` colons of the block:
+* `tip` renders a green block. Use this for general hints like best practices or ideal use cases.
+* `warning` renders a yellow block. Use this for anything the user should be aware about, like deprecation notes, experimental or beta features, etc.
+* `danger` renders a red block. Use this for known issues, incompatibilities, or potentially destructive operations.
+:::
+
+::: block title
+(optional) The title is defined by plain text following the `type`, separated by a space. See the note above about special characters in titles.
+:::
+
+Any markdown you add between the opening and closing `:::` will be rendered as block content.
+
+## Pre-configured custom blocks
+
+This documentation comes with pre-configured custom block formatting for the following types.
+
+::: tip Configuration
+These custom blocks are build on top of `vuepress-plugin-container`, which is defined as a dependency in `package.json`, and configured in `config.js` via the `container` plugin.
+Their styling is defined in `/content/.vuepress/theme/styles/*.styl` and imported in `/content/.vuepress/theme/styles/index.styl`.
+:::
+
+### Flag
+
+Use this to document CLI commands, configuration flags, and similar ways to configure and customize KUDO:
 
 ```markdown
 ::: flag kubectl kudo version
@@ -27,23 +53,17 @@ The above example renders like this:
 Print the current KUDO package version.
 :::
 
-### Flag Properties
+### Attribute
 
-Custom blocks have two properties:
+Use this to document structure of YAML files.
 
-::: flag type
-The type is defined by the first word following the opening `:::` colons of the block:
-* `tip` renders a green block. Use this for general hints like best practices or ideal use cases.
-* `warning` renders a yellow block. Use this for anything the user should be aware about, like deprecation notes, experimental or beta features, etc.
-* `danger` renders a red block. Use this for known issues, incompatibilities, or potentially destructive operations.
+```markdown
+::: attribute name
+A required attribute which provides a name to the parameter.
 :::
+```
 
-::: flag title
-(optional) The title is defined by plain text following the `type`, separated by a space. See the note above about special characters in titles.
-:::
-
-Any markdown you add between the opening and closing `:::` will be rendered as block content.
-
-::: tip Flag Configuration
-The `flag` custom block is build on top of `vuepress-plugin-container`, which is defined as a dependency in `package.json`, and configured in `config.js` via the `container` plugin. Its styling is defined in `/content/.vuepress/theme/styles/flag.styl` and imported in `/content/.vuepress/theme/styles/index.styl`.
+The above example renders like this:
+::: attribute name
+A required attribute which provides a name to the parameter.
 :::


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a custom block for YAML attributes.
Document operator parameters. (Hemingway grade 7).

**Which issue(s) this PR fixes**:
Fixes #141 