### PR TITLE
cli: update examples that refer to --version

### DIFF
--- a/content/docs/cli.md
+++ b/content/docs/cli.md
@@ -131,7 +131,7 @@ The namespace used for the operator installation. (default: "default")
 :::
 
 ::: flag --operator-version (string)
-A specific operator version int the official GitHub repo. (default to the most recent)
+A specific operator version in the official GitHub repo. (default to the most recent)
 :::
 
 ::: flag -p, --parameter (stringArray)
@@ -151,7 +151,7 @@ KUDO itself is a Kubernetes operator. As such it requires the installation of CR
 
 * `kubectl kudo init --wait --wait-timeout 600` which will install CRDS, install KUDO and will wait up to 600 seconds for KUDO to be responsive.
 * `kubectl kudo init --dry-run --output=yaml > kudo-install.yaml` which will not install anything but will output YAML to a file which can be applied manually to the server.
-* `kubectl kudo init --version=0.10.0` which will install the `0.10.0` into the cluster using the image `kudobuilder/controller:v0.5.0`
+* `kubectl kudo init --version=0.10.0` which will install the `0.10.0` version in the cluster using the `kudobuilder/controller:v0.10.0` image
 * `kubectl kudo init --kudo-image=mycompany/controller:v0.6.0` allowing for user certified images or air-gapped alternative images to be installed.
 * `kubectl kudo init --client-only` which will not apply any changes to the cluster. It will setup the default KUDO home with repository options.
 * `kubectl kudo init --crd-only` will create crds in the cluster.

--- a/content/docs/cli.md
+++ b/content/docs/cli.md
@@ -102,6 +102,10 @@ Print the current KUDO version.
 `kubectl kudo install <name> [flags]`
 :::
 
+::: flag --app-version (string)
+A specific app version in the official GitHub repo. (default to the most recent)
+:::
+
 ::: flag --auto-approve
 Skip interactive approval when existing version found. (default `false`)
 :::
@@ -126,8 +130,8 @@ The file path to Kubernetes configuration file. (default: "$HOME/.kube/config")
 The namespace used for the operator installation. (default: "default")
 :::
 
-::: flag --package-version (string)
-A specific package version on the official GitHub repo. (default to the most recent)
+::: flag --operator-version (string)
+A specific operator version int the official GitHub repo. (default to the most recent)
 :::
 
 ::: flag -p, --parameter (stringArray)
@@ -147,7 +151,7 @@ KUDO itself is a Kubernetes operator. As such it requires the installation of CR
 
 * `kubectl kudo init --wait --wait-timeout 600` which will install CRDS, install KUDO and will wait up to 600 seconds for KUDO to be responsive.
 * `kubectl kudo init --dry-run --output=yaml > kudo-install.yaml` which will not install anything but will output YAML to a file which can be applied manually to the server.
-* `kubectl kudo init --version=0.5.0` which will install the `0.5.0` into the cluster using the image `kudobuilder/controller:v0.5.0`
+* `kubectl kudo init --version=0.10.0` which will install the `0.10.0` into the cluster using the image `kudobuilder/controller:v0.5.0`
 * `kubectl kudo init --kudo-image=mycompany/controller:v0.6.0` allowing for user certified images or air-gapped alternative images to be installed.
 * `kubectl kudo init --client-only` which will not apply any changes to the cluster. It will setup the default KUDO home with repository options.
 * `kubectl kudo init --crd-only` will create crds in the cluster.
@@ -182,6 +186,18 @@ kubectl kudo install kafka
 ```
 
 Both of these options will install new instance of that operator into your cluster. By default, the instance name will be generated.
+
+```bash
+kubectl kudo install kafka --app-version=2.4.0
+```
+
+This will install new instance of Kafka Operator which maps to Kafka app version 2.4.0
+
+```bash
+kubectl kudo install kafka --operator-version=1.2.0
+```
+
+This will install new instance ofq Kafka Operator which maps to Kafka operator version 1.2.0
 
 ### Install a Package Overriding Instance Name and Parameters
 

--- a/content/docs/cli.md
+++ b/content/docs/cli.md
@@ -197,7 +197,7 @@ This will install new instance of Kafka Operator which maps to Kafka app version
 kubectl kudo install kafka --operator-version=1.2.0
 ```
 
-This will install new instance ofq Kafka Operator which maps to Kafka operator version 1.2.0
+This will install new instance of Kafka Operator which maps to Kafka operator version 1.2.0
 
 ### Install a Package Overriding Instance Name and Parameters
 

--- a/content/docs/examples/apache-flink.md
+++ b/content/docs/examples/apache-flink.md
@@ -24,17 +24,17 @@ If you’re using a different way to provision Kubernetes, make sure you have at
 For our demo, we use Kafka and Flink which depend on ZooKeeper. To make the ZooKeeper Operator available on the cluster, run:
 
 ```bash
-$ kubectl kudo install zookeeper --version=0.2.0 --skip-instance
+$ kubectl kudo install zookeeper --operator-version=0.3.0 --skip-instance
 ```
 
 The `--skip-instance` flag skips the creation of a ZooKeeper instance. The flink-demo Operator that we’re going to install below will create it as a dependency instead. Now let’s make the Kafka and Flink Operators available the same way:
 
 ```bash
-$ kubectl kudo install kafka --version=0.1.3 --skip-instance
+$ kubectl kudo install kafka --operator-version=1.2.0 --skip-instance
 ```
 
 ```bash
-$ kubectl kudo install flink --version=0.1.1 --skip-instance
+$ kubectl kudo install flink --operator-version=0.2.1 --skip-instance
 ```
 
 This installs all the Operator versions needed for our demo.
@@ -65,7 +65,7 @@ This time we didn’t include the `--skip-instance` flag, so KUDO will actually 
 $ kubectl kudo plan status --instance flink-demo
 Plan(s) for "flink-demo" in namespace "default":
 .
-└── flink-demo (Operator-Version: "flink-demo-0.1.1" Active-Plan: "deploy")
+└── flink-demo (Operator-Version: "flink-demo-0.1.4" Active-Plan: "deploy")
 	└── Plan deploy (serial strategy) [IN_PROGRESS]
     	├── Phase dependencies [IN_PROGRESS]
     	│   ├── Step zookeeper (COMPLETE)
@@ -85,14 +85,14 @@ The output shows that the “deploy” plan is in progress and that it consists 
 $ kubectl kudo plan status --instance flink-demo-kafka
 Plan(s) for "flink-demo-kafka" in namespace "default":
 .
-└── flink-demo-kafka (Operator-Version: "kafka-0.1.3" Active-Plan: "deploy")
-	├── Plan deploy (serial strategy) [IN_PROGRESS]
-	│   └── Phase deploy-kafka [IN_PROGRESS]
-	│   	└── Step deploy (IN_PROGRESS)
-	└── Plan not-allowed (serial strategy) [NOT ACTIVE]
-    	└── Phase not-allowed (serial strategy) [NOT ACTIVE]
-        	└── Step not-allowed (serial strategy) [NOT ACTIVE]
-            	└── not-allowed [NOT ACTIVE]
+└── flink-demo-kafka (Operator-Version: "kafka-1.2.0" Active-Plan: "deploy")
+    ├── Plan deploy (serial strategy) [IN_PROGRESS]
+    │   └── Phase deploy-kafka [IN_PROGRESS]
+    │       └── Step deploy (IN_PROGRESS)
+    └── Plan not-allowed (serial strategy) [NOT ACTIVE]
+        └── Phase not-allowed (serial strategy) [NOT ACTIVE]
+            └── Step not-allowed (serial strategy) [NOT ACTIVE]
+                └── not-allowed [NOT ACTIVE]
 ```
 
 After Kafka was successfully installed the next phase “flink-cluster” will start and bring up, you guessed it, your flink-cluster. After this is done, the demo phase creates the generator and actor pods that generate and display transactions for this demo. Lastly, we have the flink-job phase in which we submit the actual FinancialFraudJob to the Flink cluster. Once the flink job is submitted, we will be able to see fraud logs in our actor pod shortly after.


### PR DESCRIPTION
**What this PR does / why we need it**:
- add examples to help users with `--operator-version` and `--app-version`
- adds also `--operator-version` and `--app-version` to install flags section
- changes flink demo versions so they are working with `--operator-version` and new versions 
