### PR TITLE
Add some community resources that were dropped accidentally

### DIFF
--- a/content/community/assets/resources.json
+++ b/content/community/assets/resources.json
@@ -7,6 +7,20 @@
       "url": "https://github.com/realmbgl/kudo-tutorial"
     },
     {
+      "resourceType": "Webinar",
+      "date": "2019-10-16",
+      "title": "CNCF Webinar series: Introducing the Kubernetes Universal Declarative Operator",
+      "author": "Gerred Dillon",
+      "video": "https://www.cncf.io/webinars/introducing-the-kubernetes-universal-declarative-operator/"
+    },
+    {
+      "resourceType": "Podcast",
+      "date": "2019-10-16",
+      "title": "Kubernetes Podcast #78: KUDO, with Gerred Dillon",
+      "author": "Craig Box & Adam Glick",
+      "url": "https://kubernetespodcast.com/episode/078-kudo/"
+    },
+    {
       "resourceType": "Event",
       "date": "2019-05-14",
       "title": "KUDO - Kubernetes Operators, the easy way",


### PR DESCRIPTION
We missed rebasing when landing #34; at the time, both the webinar and podcast were linked to from the landing page so we weren't really missing them. This commit adds them again to the community content section.