### PR TITLE
Update notes on KIND to remove persistent storage workaround

### DIFF
--- a/content/docs/README.md
+++ b/content/docs/README.md
@@ -55,12 +55,4 @@ $ minikube start --cpus=4 --memory=10240 --disk-size=40g
 
 ## Notes on KIND
 
-In order to use KIND with storage Operators, it is necessary to modify its Persistent Storage ([more details](https://dischord.org/2019/07/11/persistent-storage-kind/)).
-
-Here is an example of setting up a new cluster:
-
-```bash
-$ kind create cluster
-$ export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
-$ kubectl apply -f https://raw.githubusercontent.com/kudobuilder/operators/master/test/manifests/local-path-storage.yaml
-```
+In order to use KIND with storage Operators, you must be using KIND version 0.7.0 or newer.


### PR DESCRIPTION
**What this PR does / why we need it**:
The [most recent release (0.7.0) of KIND](https://github.com/kubernetes-sigs/kind/releases/tag/v0.7.0) has built-in support for dynamic PersistentVolumes out of the box, so this workaround is no longer necessary as long as we suggest people use this version.

