### PR TITLE
kafka: add how to debug KUDO kafka runbook

### DIFF
--- a/content/.vuepress/config.js
+++ b/content/.vuepress/config.js
@@ -91,7 +91,8 @@ module.exports = {
                     title: 'Kafka',
                     children: [
                       'runbooks/kafka/upgrade-kafka',
-                      'runbooks/kafka/external-kafka'
+                      'runbooks/kafka/external-kafka',
+                      'runbooks/kafka/debug-kafka'
                     ]
                   },
                   {

--- a/content/docs/runbooks/kafka/debug-kafka.md
+++ b/content/docs/runbooks/kafka/debug-kafka.md
@@ -14,7 +14,7 @@ This runbook explains how to debug a KUDO Kafka cluster.
 
 ### Verifying if KUDO Kafka plans are COMPLETE
 
-#### 1. Get the KUDO Kafka Instance object name
+#### Get the KUDO Kafka Instance object name
 
 Verify the KUDO Kafka instance object is present in the expected namespace
 
@@ -28,7 +28,7 @@ kafka-instance       82m
 zookeeper-instance   82m
 ```
 
-#### 2. Verify the KUDO Kafka plans
+#### Verify the KUDO Kafka plans
 
 `kubectl kudo plan status  --instance=kafka-instance`
 
@@ -49,7 +49,7 @@ Plan(s) for "kafka-instance" in namespace "default":
             └── Step not-allowed [NOT ACTIVE]
 ```
 
-#### 3. Get all KUDO Kafka instance pods
+#### Get all KUDO Kafka instance pods
 
 We can use the KUDO Kafka instance name to retrieve all pods for KUDO Kafka cluster.
 
@@ -65,7 +65,7 @@ kafka-instance-kafka-2   2/2     Running   0          123m
 
 ### Debugging the pods logs
 
-#### 4. Get logs from KUDO Kafka combined pods 
+#### Get logs from KUDO Kafka combined pods 
 
 Sometimes we need the combined logs output of all the Kafka pods:
 `kubectl logs -l  kudo.dev/instance=kafka-instance -c k8skafka -f`
@@ -97,7 +97,7 @@ expected output is the current logs from all the Kafka pods, we can identify to 
 [2020-02-03 12:32:09,613] INFO [GroupMetadataManager brokerId=0] Removed 0 expired offsets in 0 milliseconds. (kafka.coordinator.group.GroupMetadataManager)
 ```
 
-#### 5. Get logs from KUDO Kafka individual pod
+#### Get logs from KUDO Kafka individual pod
 
 `kubectl logs kafka-instance-kafka-0 -c k8skafka`
 
@@ -111,7 +111,7 @@ expected output is the current logs from all the Kafka pods, we can identify to 
 [ ... lines removed for clarity ...]
 ```
 
-#### 6. Get logs from KUDO Kafka node exporter container
+#### Get logs from KUDO Kafka node exporter container
 
 `kubectl logs kafka-instance-kafka-0 -c kafka-node-exporter`
 
@@ -124,7 +124,7 @@ time="2020-02-03T10:31:44Z" level=info msg="Build context (go=go1.12.5, user=roo
 
 ### Debugging service issues
 
-#### 7. Verify the service endpoints
+#### Verify the service endpoints
 
 `kubectl get endpoints kafka-instance-svc -o json | jq  -r '.subsets[].addresses[].hostname'`
 
@@ -135,7 +135,7 @@ kafka-instance-kafka-0
 kafka-instance-kafka-1
 ```
 
-#### 8. Verify the service selector labels are matching the ones in pods
+#### Verify the service selector labels are matching the ones in pods
 
 Get the labels presents in the Kafka pods
 
@@ -181,7 +181,7 @@ expected output are the two labels the service use to find the Kafka pods:
 
 ### Debugging health of all objects
 
-#### 9. Get list of all objects created by KUDO Kafka Instance
+#### Get list of all objects created by KUDO Kafka Instance
 
 `kubectl api-resources --verbs=get --namespaced -o name \
   | xargs -n 1 kubectl get --show-kind --ignore-not-found -l kudo.dev/instance=kafka-instance`
@@ -225,7 +225,7 @@ role.rbac.authorization.k8s.io/kafka-instance-role   5h29m
 
 ### Debugging deployment issues
 
-#### 10. Pod stuck with Status `ContainerCreating` 
+#### Pod stuck with Status `ContainerCreating` 
 
 After deploying KUDO Kafka if the pods are stuck in `ContainerCreating` status. It can be caused by several issues caused by resource starvation to storage issues.
 
@@ -265,7 +265,7 @@ default       54s         Warning   FailedAttachVolume       pod/kafka-instance-
 
 we can see that the root cause of the container being stuck is an issue with the PersistentVolume.
 
-#### 8. Pod stuck with Status `Pending` 
+#### Pod stuck with Status `Pending` 
 
 Same debugging can be applied for the pods stuck in other states like `Pending`. 
 

--- a/content/docs/runbooks/kafka/debug-kafka.md
+++ b/content/docs/runbooks/kafka/debug-kafka.md
@@ -1,0 +1,309 @@
+# Debugging a KUDO Kafka cluster 
+
+This runbook explains how to debug a KUDO Kafka cluster.
+
+
+## Pre-conditions
+
+- Kubernetes cluster with KUDO version >= 0.10.1 installed
+- Have a KUDO Kafka cluster version 1.2.0 up and running in the namespace `kudo-kafka`
+- Have binary of `jq` installed in the `$PATH`
+
+
+## Steps
+
+### Verifying if KUDO Kafka plans are COMPLETE
+
+#### 1. Get the KUDO Kafka Instance object name
+
+Verify the KUDO Kafka instance object is present in the expected namespace
+
+`kubectl get instances`
+
+expected output is the KUDO Instance objects present in the namespace `default`:
+
+```bash
+NAME                 AGE
+kafka-instance       82m
+zookeeper-instance   82m
+```
+
+#### 2. Verify the KUDO Kafka plans
+
+`kubectl kudo plan status  --instance=kafka-instance`
+
+expected output is the current status of the KUDO Kafka instance plans:
+
+```
+Plan(s) for "kafka-instance" in namespace "default":
+.
+└── kafka-instance (Operator-Version: "kafka-1.2.0" Active-Plan: "deploy")
+    ├── Plan deploy (serial strategy) [COMPLETE]
+    │   └── Phase deploy-kafka (serial strategy) [COMPLETE]
+    │       └── Step deploy [COMPLETE]
+    ├── Plan mirrormaker (serial strategy) [NOT ACTIVE]
+    │   └── Phase deploy-mirror-maker (serial strategy) [NOT ACTIVE]
+    │       └── Step deploy [NOT ACTIVE]
+    └── Plan not-allowed (serial strategy) [NOT ACTIVE]
+        └── Phase not-allowed (serial strategy) [NOT ACTIVE]
+            └── Step not-allowed [NOT ACTIVE]
+```
+
+#### 3. Get all KUDO Kafka instance pods
+
+We can use the KUDO Kafka instance name to retrieve all pods for KUDO Kafka cluster.
+
+`kubectl get pods -l kudo.dev/instance=kafka-instance`
+
+expected output is the pods list that belong to the current KUDO Kafka instance:
+```
+NAME                     READY   STATUS    RESTARTS   AGE
+kafka-instance-kafka-0   2/2     Running   1          124m
+kafka-instance-kafka-1   2/2     Running   0          124m
+kafka-instance-kafka-2   2/2     Running   0          123m
+```
+
+### Debugging the pods logs
+
+#### 4. Get logs from KUDO Kafka combined pods 
+
+Sometimes we need the combined logs output of all the Kafka pods:
+`kubectl logs -l  kudo.dev/instance=kafka-instance -c k8skafka -f`
+
+
+expected output is the current logs from all the Kafka pods, we can identify to which broker each line belong by the `brokerId` present in log lines:
+
+```
+[2020-02-03 12:13:22,030] INFO [GroupMetadataManager brokerId=2] Removed 0 expired offsets in 0 milliseconds. (kafka.coordinator.group.GroupMetadataManager)
+[2020-02-03 12:23:22,030] INFO [GroupMetadataManager brokerId=2] Removed 0 expired offsets in 0 milliseconds. (kafka.coordinator.group.GroupMetadataManager)
+[2020-02-03 12:33:22,030] INFO [GroupMetadataManager brokerId=2] Removed 0 expired offsets in 0 milliseconds. (kafka.coordinator.group.GroupMetadataManager)
+[2020-02-03 11:02:36,834] INFO [GroupMetadataManager brokerId=1] Removed 0 expired offsets in 0 milliseconds. (kafka.coordinator.group.GroupMetadataManager)
+[2020-02-03 11:12:36,834] INFO [GroupMetadataManager brokerId=1] Removed 0 expired offsets in 0 milliseconds. (kafka.coordinator.group.GroupMetadataManager)
+[2020-02-03 11:22:36,834] INFO [GroupMetadataManager brokerId=1] Removed 0 expired offsets in 0 milliseconds. (kafka.coordinator.group.GroupMetadataManager)
+[2020-02-03 11:32:36,834] INFO [GroupMetadataManager brokerId=1] Removed 0 expired offsets in 0 milliseconds. (kafka.coordinator.group.GroupMetadataManager)
+[2020-02-03 11:42:36,834] INFO [GroupMetadataManager brokerId=1] Removed 0 expired offsets in 0 milliseconds. (kafka.coordinator.group.GroupMetadataManager)
+[2020-02-03 11:52:36,834] INFO [GroupMetadataManager brokerId=1] Removed 0 expired offsets in 0 milliseconds. (kafka.coordinator.group.GroupMetadataManager)
+[2020-02-03 12:02:36,834] INFO [GroupMetadataManager brokerId=1] Removed 0 expired offsets in 0 milliseconds. (kafka.coordinator.group.GroupMetadataManager)
+[2020-02-03 12:12:36,834] INFO [GroupMetadataManager brokerId=1] Removed 0 expired offsets in 0 milliseconds. (kafka.coordinator.group.GroupMetadataManager)
+[2020-02-03 12:22:36,834] INFO [GroupMetadataManager brokerId=1] Removed 0 expired offsets in 0 milliseconds. (kafka.coordinator.group.GroupMetadataManager)
+[2020-02-03 12:32:36,834] INFO [GroupMetadataManager brokerId=1] Removed 0 expired offsets in 0 milliseconds. (kafka.coordinator.group.GroupMetadataManager)
+[2020-02-03 11:22:09,613] INFO [GroupMetadataManager brokerId=0] Removed 0 expired offsets in 0 milliseconds. (kafka.coordinator.group.GroupMetadataManager)
+[2020-02-03 11:32:09,613] INFO [GroupMetadataManager brokerId=0] Removed 0 expired offsets in 0 milliseconds. (kafka.coordinator.group.GroupMetadataManager)
+[2020-02-03 11:42:09,613] INFO [GroupMetadataManager brokerId=0] Removed 0 expired offsets in 0 milliseconds. (kafka.coordinator.group.GroupMetadataManager)
+[2020-02-03 11:52:09,613] INFO [GroupMetadataManager brokerId=0] Removed 0 expired offsets in 0 milliseconds. (kafka.coordinator.group.GroupMetadataManager)
+[2020-02-03 12:02:09,613] INFO [GroupMetadataManager brokerId=0] Removed 0 expired offsets in 0 milliseconds. (kafka.coordinator.group.GroupMetadataManager)
+[2020-02-03 12:12:09,613] INFO [GroupMetadataManager brokerId=0] Removed 0 expired offsets in 0 milliseconds. (kafka.coordinator.group.GroupMetadataManager)
+[2020-02-03 12:22:09,613] INFO [GroupMetadataManager brokerId=0] Removed 0 expired offsets in 0 milliseconds. (kafka.coordinator.group.GroupMetadataManager)
+[2020-02-03 12:32:09,613] INFO [GroupMetadataManager brokerId=0] Removed 0 expired offsets in 0 milliseconds. (kafka.coordinator.group.GroupMetadataManager)
+```
+
+#### 4. Get logs from KUDO Kafka individual pod
+
+`k logs kafka-instance-kafka-0 -c k8skafka`
+
+```
+[ ... lines removed for clarity ...]
+[2020-02-03 11:52:09,613] INFO [GroupMetadataManager brokerId=0] Removed 0 expired offsets in 0 milliseconds. (kafka.coordinator.group.GroupMetadataManager)
+[2020-02-03 12:02:09,613] INFO [GroupMetadataManager brokerId=0] Removed 0 expired offsets in 0 milliseconds. (kafka.coordinator.group.GroupMetadataManager)
+[2020-02-03 12:12:09,613] INFO [GroupMetadataManager brokerId=0] Removed 0 expired offsets in 0 milliseconds. (kafka.coordinator.group.GroupMetadataManager)
+[2020-02-03 12:22:09,613] INFO [GroupMetadataManager brokerId=0] Removed 0 expired offsets in 0 milliseconds. (kafka.coordinator.group.GroupMetadataManager)
+[2020-02-03 12:32:09,613] INFO [GroupMetadataManager brokerId=0] Removed 0 expired offsets in 0 milliseconds. (kafka.coordinator.group.GroupMetadataManager)
+[ ... lines removed for clarity ...]
+```
+
+#### 4. Get logs from KUDO Kafka node exporter container
+
+`kubectl logs kafka-instance-kafka-0 -c kafka-node-exporter`
+
+
+expected output is the logs from the node exporter container running as a sidecar with the broker 0 of Kafka:
+```
+time="2020-02-03T10:31:44Z" level=info msg="Starting node_exporter (version=0.18.1, branch=HEAD, revision=3db77732e925c08f675d7404a8c46466b2ece83e)" source="node_exporter.go:156"
+time="2020-02-03T10:31:44Z" level=info msg="Build context (go=go1.12.5, user=root@b50852a1acba, date=20190604-16:41:18)" source="node_exporter.go:157"
+```
+
+### Debugging service issues
+
+#### 5. Verify the service endpoints
+
+`kubectl get endpoints kafka-instance-svc -o json | jq  -r '.subsets[].addresses[].hostname'`
+
+expected output is the pods name for the brokers:
+```
+kafka-instance-kafka-2
+kafka-instance-kafka-0
+kafka-instance-kafka-1
+```
+
+#### 6. Verify the service selector labels are matching the ones in pods
+
+Get the labels presents in the Kafka pods
+
+`kubectl get pods -l kudo.dev/instance=kafka-instance -o json | jq -r '.items[].metadata.labels'`
+
+expected output is the list of the labels used in the pods of `kafka-instance` cluster:
+
+```
+{
+  "app": "kafka",
+  "controller-revision-hash": "kafka-instance-kafka-76b8b8559b",
+  "kafka": "kafka",
+  "kudo.dev/instance": "kafka-instance",
+  "statefulset.kubernetes.io/pod-name": "kafka-instance-kafka-0"
+}
+{
+  "app": "kafka",
+  "controller-revision-hash": "kafka-instance-kafka-76b8b8559b",
+  "kafka": "kafka",
+  "kudo.dev/instance": "kafka-instance",
+  "statefulset.kubernetes.io/pod-name": "kafka-instance-kafka-1"
+}
+{
+  "app": "kafka",
+  "controller-revision-hash": "kafka-instance-kafka-76b8b8559b",
+  "kafka": "kafka",
+  "kudo.dev/instance": "kafka-instance",
+  "statefulset.kubernetes.io/pod-name": "kafka-instance-kafka-2"
+}
+```
+
+Now we need to verify that the service selector is using a subset of these labels
+
+`kubectl get svc kafka-instance-svc -o json | jq -r '.spec.selector'`
+
+expected output are the two labels the service use to find the Kafka pods: 
+```
+{
+  "app": "kafka",
+  "kudo.dev/instance": "kafka-instance"
+}
+```
+
+### Debugging health of all objects
+
+#### 7. Get list of all objects created by KUDO Kafka Instance
+
+`kubectl api-resources --verbs=get --namespaced -o name \
+  | xargs -n 1 kubectl get --show-kind --ignore-not-found -l kudo.dev/instance=kafka-instance`
+
+expected output are all resources which are created by the KUDO Kafka Instance `kafka-instance`. The list can be different based on different features enabled in KUDO Kafka.
+
+```
+NAME                                           DATA   AGE
+configmap/kafka-instance-bootstrap             1      5h26m
+configmap/kafka-instance-enable-tls            1      5h26m
+configmap/kafka-instance-health-check-script   1      5h26m
+configmap/kafka-instance-jaas-config           1      5h26m
+configmap/kafka-instance-krb5-config           1      5h26m
+configmap/kafka-instance-metrics-config        1      5h26m
+configmap/kafka-instance-serverproperties      1      5h26m
+NAME                           ENDPOINTS                                                                AGE
+endpoints/kafka-instance-svc   192.168.183.18:9096,192.168.51.87:9096,192.168.65.150:9096 + 9 more...   5h26m
+NAME                         READY   STATUS    RESTARTS   AGE
+pod/kafka-instance-kafka-0   2/2     Running   1          5h26m
+pod/kafka-instance-kafka-1   2/2     Running   0          5h25m
+pod/kafka-instance-kafka-2   2/2     Running   0          5h25m
+NAME                            SECRETS   AGE
+serviceaccount/kafka-instance   1         5h26m
+NAME                         TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)                               AGE
+service/kafka-instance-svc   ClusterIP   None         <none>        9093/TCP,9092/TCP,9094/TCP,9096/TCP   5h26m
+NAME                                                      CONTROLLER                              REVISION   AGE
+controllerrevision.apps/kafka-instance-kafka-76b8b8559b   statefulset.apps/kafka-instance-kafka   1          5h26m
+NAME                                    READY   AGE
+statefulset.apps/kafka-instance-kafka   3/3     5h26m
+NAME                                               AGE
+podmetrics.metrics.k8s.io/kafka-instance-kafka-1   1s
+podmetrics.metrics.k8s.io/kafka-instance-kafka-2   1s
+podmetrics.metrics.k8s.io/kafka-instance-kafka-0   1s
+NAME                                            MIN AVAILABLE   MAX UNAVAILABLE   ALLOWED DISRUPTIONS   AGE
+poddisruptionbudget.policy/kafka-instance-pdb   N/A             1                 1                     5h29m
+NAME                                                           AGE
+rolebinding.rbac.authorization.k8s.io/kafka-instance-binding   5h29m
+NAME                                                 AGE
+role.rbac.authorization.k8s.io/kafka-instance-role   5h29m
+```
+
+### Debugging deployment issues
+
+#### 8. Pod stuck with Status `ContainerCreating` 
+
+After deploying KUDO Kafka if the pods are stuck in `ContainerCreating` status. It can be caused by several issues caused by resource starvation to storage issues.
+
+To debug the root cause of the `ContainerCreating` issue for KUDO Kafka. For example for the next case:
+```
+kubectl get pods 
+NAME                             READY   STATUS              RESTARTS   AGE
+kafka-instance-kafka-0           0/2     ContainerCreating   0          4m17s
+```
+Run the `pod describe` command and look for the events related to the pod
+
+`kubectl describe pod kafka-instance-kafka-0`
+
+expected output should reveal some reasons that are stopping the scheduling of the pod
+
+```
+[ ... lines removed for clarity ...]
+Events:
+  Type     Reason              Age                  From                                                Message
+  ----     ------              ----                 ----                                                -------
+  Normal   Scheduled           <unknown>            default-scheduler                                   Successfully assigned default/kafka-instance-kafka-0 to ip-10-0-128-61.us-west-2.compute.internal
+  Warning  FailedMount         36s                  kubelet, ip-10-0-128-61.us-west-2.compute.internal  Unable to attach or mount volumes: unmounted volumes=[kafka-instance-datadir], unattached volumes=[config health-check-script metrics kafka-instance-datadir kafka-instance-token-m2d2h bootstrap]: timed out waiting for the condition
+[ ... lines removed for clarity ...]
+```
+
+Here we can see that the issue was caused by the `FailedMount` event.
+
+To get more details on what is happening we can fetch the events 
+
+`kubectl get events --sort-by='.metadata.creationTimestamp'`
+
+```
+[ ... lines removed for clarity ...]
+default       54s         Warning   FailedAttachVolume       pod/kafka-instance-kafka-0                                                        AttachVolume.Attach failed for volume "pvc-e949f30a-79d6-46ba-9ec1-5658c8e66c17" : PersistentVolume "pvc-e949f30a-79d6-46ba-9ec1-5658c8e66c17" is marked for deletion
+[ ... lines removed for clarity ...]
+```
+
+we can see that the root cause of the container being stuck is an issue with the PersistentVolume.
+
+#### 8. Pod stuck with Status `Pending` 
+
+Same debugging can be applied for the pods stuck in other states like `Pending`. 
+
+`kubectl get pods`
+
+expected output is a list of pods with one `Pending` pod:
+```
+NAME                             READY   STATUS    RESTARTS   AGE
+kafka-instance-kafka-0           2/2     Running   0          35m
+kafka-instance-kafka-1           2/2     Running   0          35m
+kafka-instance-kafka-2           0/2     Pending   0          17s
+```
+
+Run the `pod describe` command and look for the events related to the pod
+
+`kubectl describe pod kafka-instance-kafka-2`
+
+expected output should reveal some reasons that are stopping the scheduling of the pod
+
+```
+[ ... lines removed for clarity ...]
+Events:
+  Type     Reason            Age        From               Message
+  ----     ------            ----       ----               -------
+  Warning  FailedScheduling  <unknown>  default-scheduler  0/7 nodes are available: 7 Insufficient memory.
+[ ... lines removed for clarity ...]
+```
+We can see that pod is in Pending state because of insufficient memory.
+
+Same can be also be retrieved by checking the events
+`kubectl get events --sort-by='.metadata.creationTimestamp'`
+
+expected output should reveal that pod `kafka-instance-kafka-2` is stuck due to resource starvation
+
+```
+[ ... lines removed for clarity ...]
+
+default     <unknown>   Warning   FailedScheduling         pod/kafka-instance-kafka-2         0/7 nodes are available: 7 Insufficient memory.
+[ ... lines removed for clarity ...]
+```
+

--- a/content/docs/runbooks/kafka/debug-kafka.md
+++ b/content/docs/runbooks/kafka/debug-kafka.md
@@ -97,9 +97,9 @@ expected output is the current logs from all the Kafka pods, we can identify to 
 [2020-02-03 12:32:09,613] INFO [GroupMetadataManager brokerId=0] Removed 0 expired offsets in 0 milliseconds. (kafka.coordinator.group.GroupMetadataManager)
 ```
 
-#### 4. Get logs from KUDO Kafka individual pod
+#### 5. Get logs from KUDO Kafka individual pod
 
-`k logs kafka-instance-kafka-0 -c k8skafka`
+`kubectl logs kafka-instance-kafka-0 -c k8skafka`
 
 ```
 [ ... lines removed for clarity ...]
@@ -111,7 +111,7 @@ expected output is the current logs from all the Kafka pods, we can identify to 
 [ ... lines removed for clarity ...]
 ```
 
-#### 4. Get logs from KUDO Kafka node exporter container
+#### 6. Get logs from KUDO Kafka node exporter container
 
 `kubectl logs kafka-instance-kafka-0 -c kafka-node-exporter`
 
@@ -124,7 +124,7 @@ time="2020-02-03T10:31:44Z" level=info msg="Build context (go=go1.12.5, user=roo
 
 ### Debugging service issues
 
-#### 5. Verify the service endpoints
+#### 7. Verify the service endpoints
 
 `kubectl get endpoints kafka-instance-svc -o json | jq  -r '.subsets[].addresses[].hostname'`
 
@@ -135,7 +135,7 @@ kafka-instance-kafka-0
 kafka-instance-kafka-1
 ```
 
-#### 6. Verify the service selector labels are matching the ones in pods
+#### 8. Verify the service selector labels are matching the ones in pods
 
 Get the labels presents in the Kafka pods
 
@@ -181,7 +181,7 @@ expected output are the two labels the service use to find the Kafka pods:
 
 ### Debugging health of all objects
 
-#### 7. Get list of all objects created by KUDO Kafka Instance
+#### 9. Get list of all objects created by KUDO Kafka Instance
 
 `kubectl api-resources --verbs=get --namespaced -o name \
   | xargs -n 1 kubectl get --show-kind --ignore-not-found -l kudo.dev/instance=kafka-instance`
@@ -225,7 +225,7 @@ role.rbac.authorization.k8s.io/kafka-instance-role   5h29m
 
 ### Debugging deployment issues
 
-#### 8. Pod stuck with Status `ContainerCreating` 
+#### 10. Pod stuck with Status `ContainerCreating` 
 
 After deploying KUDO Kafka if the pods are stuck in `ContainerCreating` status. It can be caused by several issues caused by resource starvation to storage issues.
 
@@ -306,4 +306,3 @@ expected output should reveal that pod `kafka-instance-kafka-2` is stuck due to 
 default     <unknown>   Warning   FailedScheduling         pod/kafka-instance-kafka-2         0/7 nodes are available: 7 Insufficient memory.
 [ ... lines removed for clarity ...]
 ```
-

--- a/content/docs/runbooks/kafka/external-kafka.md
+++ b/content/docs/runbooks/kafka/external-kafka.md
@@ -2,10 +2,10 @@
 
 This runbook explains how to expose a KUDO Kafka cluster to the outside of the Kubernetes cluster, using the `Service` of type `LoadBalancer`
 
-## Requirements
+## Pre-conditions
 
-- A Kubernetes cluster with KUDO version >= 0.10.0 installed
-- Have a KUDO Kafka cluster version 1.1.0 up and running in the namespace `kudo-kafka`
+- A Kubernetes cluster with KUDO version >= 0.10.1 installed
+- Have a KUDO Kafka cluster version 1.2.0 up and running in the namespace `kudo-kafka`
 - Have binaries of `jq` installed in the `$PATH`
 
 ## Steps

--- a/content/docs/runbooks/kafka/upgrade-kafka.md
+++ b/content/docs/runbooks/kafka/upgrade-kafka.md
@@ -3,10 +3,10 @@
 
 This runbook explains how to upgrade a running KUDO Kafka to a newer version of KUDO Kafka.
 
-## Preconditions
+## Pre-conditions
 
-- Kubernetes cluster with KUDO version >= 0.10.0 installed
-- Have a KUDO Kafka cluster version 1.1.0 up and running in the namespace `kudo-kafka`
+- Kubernetes cluster with KUDO version >= 0.10.1 installed
+- Have a KUDO Kafka cluster version 1.2.0 up and running in the namespace `kudo-kafka`
 - Have binaries of `jq` and `grep` installed in the `$PATH`
 
 ## Steps


### PR DESCRIPTION
Signed-off-by: Zain Malik <zmalikshxil@gmail.com>

**What this PR does / why we need it**:
first version of how to debug the KUDO Kafka
with examples from plan status, service label mismatch and pod scheduling errors

This runbook will most likely be extended with more common use cases
**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
fixes one part of https://github.com/kudobuilder/kudo.dev/issues/151
**Special notes for your reviewer**:

