### PR TITLE
Add Cloud Native and Kubernetes Budapest talk details

### DIFF
--- a/content/community/events/cloud-native-k8s-budapest-2029-02.md
+++ b/content/community/events/cloud-native-k8s-budapest-2029-02.md
@@ -1,0 +1,12 @@
+---
+event: Cloud Native and Kubernetes Budapest
+topic: Introducing KUDO, Kubernetes Operators made easy
+speaker: Nick Jones
+date: 2020-02-20
+location: Budapest, Hungary
+url: https://www.meetup.com/k8s-bud/events/268143065/
+---
+
+<!-- some more info about the event could go here -->
+
+<!-- more -->


### PR DESCRIPTION
**What this PR does / why we need it**:

Add an event under the community section for a KUDO talk at Cloud Native and K8s Budapest


