### PR TITLE
Fix CLI install docs.

### DIFF
--- a/content/docs/README.md
+++ b/content/docs/README.md
@@ -9,12 +9,7 @@ Before you get started using KUDO, you need to have a running Kubernetes cluster
 
 ## Install KUDO CLI
 
-Install the `kubectl kudo` plugin. To do so, please follow the [CLI plugin installation instructions](cli.md). On a Mac it is as simple as:
-
-```bash
-$ brew tap kudobuilder/tap
-$ brew install kudo-cli
-```
+Install the `kubectl kudo` plugin. To do so, please follow the [CLI plugin installation instructions](cli.md).
 
 The KUDO CLI leverages the kubectl plugin system, which gives you all its functionality under `kubectl kudo`. This is a convenient way to install and deal with your KUDO Operators.
 

--- a/content/docs/cli.md
+++ b/content/docs/cli.md
@@ -11,8 +11,6 @@ This document demonstrates how to use the CLI but also shows what happens in KUD
 ### Requirements
 
 - `kubectl` version `1.13.0` or newer
-- KUDO CRDs installed to your cluster and KUDO controller is running. See the [getting started guide](README.md) for instructions
-- `kubectl kudo` is running outside your cluster
 
 ### Installation
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:

- remove the incomplete and duplicate CLI install instructions from the README
- break the circular dependency between KUDO controller and CLI install
- remove the meaningless "`kubectl kudo` is running outside your cluster" requirement