### PR TITLE
tweak to the task name example in Operator Substance section

### DIFF
--- a/content/docs/developing-operators/getting-started.md
+++ b/content/docs/developing-operators/getting-started.md
@@ -34,7 +34,7 @@ First let’s create an `operator.yaml` file in the `./first-operator`.
 
 This is an operator with just one plan `deploy`, which has one phase and one step and represents the minimal setup. The `deploy` plan is automatically triggered when you install an instance of this operator into your cluster.
 
-You can see that the task  `app` references the resource `deployment.yaml`. KUDO expects this file to exist inside the `templates` folder. As the next step, create `templates/deployment.yaml`:
+You can see that the task `app` references the resource `deployment.yaml`. KUDO expects this file to exist inside the `templates` folder. As the next step, create `templates/deployment.yaml`:
 
 <<< @//kudo/test/integration/first-operator-test/first-operator/templates/deployment.yaml
 

--- a/content/docs/developing-operators/getting-started.md
+++ b/content/docs/developing-operators/getting-started.md
@@ -34,7 +34,7 @@ First let’s create an `operator.yaml` file in the `./first-operator`.
 
 This is an operator with just one plan `deploy`, which has one phase and one step and represents the minimal setup. The `deploy` plan is automatically triggered when you install an instance of this operator into your cluster.
 
-You can see that the task `nginx` references the resource `deployment.yaml`. KUDO expects this file to exist inside the `templates` folder. As the next step, create `templates/deployment.yaml`:
+You can see that the task `app` references the resource `deployment.yaml`. KUDO expects this file to exist inside the `templates` folder. As the next step, create `templates/deployment.yaml`:
 
 <<< @//kudo/test/integration/first-operator-test/first-operator/templates/deployment.yaml
 

--- a/content/docs/developing-operators/getting-started.md
+++ b/content/docs/developing-operators/getting-started.md
@@ -34,7 +34,7 @@ First let’s create an `operator.yaml` file in the `./first-operator`.
 
 This is an operator with just one plan `deploy`, which has one phase and one step and represents the minimal setup. The `deploy` plan is automatically triggered when you install an instance of this operator into your cluster.
 
-You can see that the task `app` references the resource `deployment.yaml`. KUDO expects this file to exist inside the `templates` folder. As the next step, create `templates/deployment.yaml`:
+You can see that the task  `app` references the resource `deployment.yaml`. KUDO expects this file to exist inside the `templates` folder. As the next step, create `templates/deployment.yaml`:
 
 <<< @//kudo/test/integration/first-operator-test/first-operator/templates/deployment.yaml
 

--- a/content/docs/developing-operators/getting-started.md
+++ b/content/docs/developing-operators/getting-started.md
@@ -34,7 +34,7 @@ First let’s create an `operator.yaml` file in the `./first-operator`.
 
 This is an operator with just one plan `deploy`, which has one phase and one step and represents the minimal setup. The `deploy` plan is automatically triggered when you install an instance of this operator into your cluster.
 
-You can see that the task `app` references the resource `deployment.yaml`. KUDO expects this file to exist inside the `templates` folder. As the next step, create `templates/deployment.yaml`:
+You can see that the task ` app` references the resource `deployment.yaml`. KUDO expects this file to exist inside the `templates` folder. As the next step, create `templates/deployment.yaml`:
 
 <<< @//kudo/test/integration/first-operator-test/first-operator/templates/deployment.yaml
 


### PR DESCRIPTION

**What this PR does / why we need it**:

I think I might have found a needed correction in the task name as specified
in the Operator Substance section of the web docs.

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

Please verify this is the intent of this doc, the example yaml might have intended
for 'nginx' to be used instead of 'app'.