### PR TITLE
Feature: Added vuepress-plugin-check-md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ dist/
 
 # Session
 Session.vim
+
+# Yarn
+yarn-error.log

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ In the root of the project, run
 ```bash
 yarn install
 make build
+yarn docs:lint
 yarn docs:dev
 
 #or make local-run target calls yarm docs:dev

--- a/content/.vuepress/config.js
+++ b/content/.vuepress/config.js
@@ -199,6 +199,9 @@ module.exports = {
             before: name => `<div class="teaser custom-block"><h2 class="custom-block-title">${name}</h2>`,
             after: '</div>',
         }],
-        [ 'feed', feed_options ]
+        [ 'feed', feed_options ],
+        ['check-md', {
+          pattern: '**/*.md',
+        }]
     ]
 };

--- a/package.json
+++ b/package.json
@@ -1,9 +1,11 @@
 {
   "license": "Apache-2.0",
   "devDependencies": {
-    "vuepress": "^1.2.0"
+    "vuepress": "^1.2.0",
+    "vuepress-plugin-check-md": "^0.0.2"
   },
   "scripts": {
+    "docs:lint": "vuepress check-md content",
     "docs:dev": "vuepress dev content",
     "docs:build": "vuepress build content",
     "docs:clean": "rm -rf node_modules && yarn install"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 cd /app
 yarn install
+yarn docs:lint
 yarn docs:dev

--- a/yarn.lock
+++ b/yarn.lock
@@ -689,6 +689,14 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
+"@sindresorhus/slugify@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/slugify/-/slugify-0.8.0.tgz#5550b7fa064f3a8a82651463ad635378054c72d0"
+  integrity sha512-Y+C3aG0JHmi4nCfixHgq0iAtqWCjMCliWghf6fXbemRKSGzpcrHdYxGZGDt8MeFg+gH7ounfMbz6WogqKCWvDg==
+  dependencies:
+    escape-string-regexp "^1.0.5"
+    lodash.deburr "^4.1.0"
+
 "@types/events@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
@@ -1772,6 +1780,17 @@ chalk@^2.0.0, chalk@^2.3.2, chalk@^2.4.1, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+check-md@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/check-md/-/check-md-1.0.0.tgz#6ba97cf4e061b23691b4132591afb168d4cd5910"
+  integrity sha512-H9LS+TDB6ix4QZQFiTp2TVIL+24zKutOKDqxIxAxnvkx3phpzrwPINaykD8RSeynxIVp3s0PecR2GEA3KLbziQ==
+  dependencies:
+    "@sindresorhus/slugify" "^0.8.0"
+    chalk "^2.4.2"
+    commander "^2.19.0"
+    diacritics "^1.3.0"
+    globby "^9.1.0"
+
 chokidar@^2.0.2, chokidar@^2.0.3, chokidar@^2.1.8:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
@@ -1918,7 +1937,7 @@ commander@2.17.x:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
   integrity sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==
 
-commander@^2.20.0:
+commander@^2.19.0, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -3239,7 +3258,7 @@ globby@^7.1.1:
     pify "^3.0.0"
     slash "^1.0.0"
 
-globby@^9.2.0:
+globby@^9.1.0, globby@^9.2.0:
   version "9.2.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-9.2.0.tgz#fd029a706c703d29bdd170f4b6db3a3f7a7cb63d"
   integrity sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==
@@ -4166,6 +4185,11 @@ lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
+
+lodash.deburr@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.deburr/-/lodash.deburr-4.1.0.tgz#ddb1bbb3ef07458c0177ba07de14422cb033ff9b"
+  integrity sha1-3bG7s+8HRYwBd7oH3hRCLLAz/5s=
 
 lodash.defaultsdeep@4.6.1:
   version "4.6.1"
@@ -6954,6 +6978,13 @@ vuepress-html-webpack-plugin@^3.2.0:
     tapable "^1.0.0"
     toposort "^1.0.0"
     util.promisify "1.0.0"
+
+vuepress-plugin-check-md@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/vuepress-plugin-check-md/-/vuepress-plugin-check-md-0.0.2.tgz#e0c5f296948fa5df24280971ee6a725c00a88738"
+  integrity sha512-XwA/IiMNvR42L3ajmkr+6JY3JRnhDN+uluh1wLYl0VAI8VqTkXT7Ng4xlxgebfLPChEFPnJgcydGv8E52Zdpig==
+  dependencies:
+    check-md "1.0.0"
 
 vuepress-plugin-container@^2.0.2:
   version "2.1.2"


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:

Added vuepress-plugin-check-md, mapped it to package.json, updated README.md to reflect usage, and to git ignoring yarn error log

**Which issue(s) this PR fixes**:

Fixes #230

Alternative solution to a full CI test. 

**Special notes for your reviewer**:

The `run.sh` script for docker `yarn docs:lint` does not exit the `run.sh`, nor does this actually fail and exit during 404 findings because we **do not** pass "StrictMode Bash" options for that script `set -euo pipefail`. Currently this acts like a warn setting. 

This could be set explicitly with:

`exitLevel: 'warn'` by adding to the `content/.vuepress/config.js#205`.

 