### PR TITLE
The URL path after the `kubectl proxy` is wrong

### DIFF
--- a/content/docs/examples/apache-flink.md
+++ b/content/docs/examples/apache-flink.md
@@ -103,7 +103,7 @@ After a while, the state of all plans, phases and steps will change to “COMPLE
 $ kubectl proxy
 ```
 
-[http://127.0.0.1:8001/api/v1/namespaces/default/services/flink-demo-flink-jobmanager:ui/proxy/#/overview](http://127.0.0.1:8001/api/v1/namespaces/default/services/flink-demo-flink-jobmanager:ui/proxy/#/overview)
+[http://127.0.0.1:8001/api/v1/namespaces/default/services/flink-jobmanager:ui/proxy/#/overview](http://127.0.0.1:8001/api/v1/namespaces/default/services/flink-jobmanager:ui/proxy/#/overview)
 
 It should look similar to this, depending on your local machine and how many cores you have available:
 


### PR DESCRIPTION
Hello together,

Couldn't reach the URL for the flink-jobmanager after running kubectl proxy

`kubectl get services` revealed the problem as the service is now called flink-jobmanager only

Please try out and merge if wanted :)

Best regards,
Alex

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

