### PR TITLE
Remove unnecessary -printf incompatible with OSX find.

### DIFF
--- a/scripts/embed-operator-docs.sh
+++ b/scripts/embed-operator-docs.sh
@@ -25,8 +25,8 @@ function embed_docs() {
     echo 'module.exports = { children: [' > "${snippet}"
     # The two find commands are a hack to put installation docs first.
     for file in \
-	    $(find "${destination}" -maxdepth 1 -type f -name '*.md' -not -name 'README.md' -name 'instal*' -printf '%f\n') \
-	    $(find "${destination}" -maxdepth 1 -type f -name '*.md' -not -name 'README.md' -not -name 'instal*' -printf '%f\n')
+	    $(find "${destination}" -maxdepth 1 -type f -name '*.md' -not -name 'README.md' -name 'instal*') \
+	    $(find "${destination}" -maxdepth 1 -type f -name '*.md' -not -name 'README.md' -not -name 'instal*')
     do
         echo "'runbooks/${name}/$(basename "${file}" .md)'," >> "${snippet}"
     done


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:

See issue. Turns out we run `basename` on the output anyway, so we can have
`find` emit full paths as well.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #274
Hopefully, since `unknown -printf` was the only error message but I don't have a Mac to verify.